### PR TITLE
Support fit files from Zwift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# indieVelo to Garmin Connect editor/uploader
+# indieVelo / Zwift to Garmin Connect editor/uploader
 
 This repo contains a script `garmin.py` that will edit [FIT](https://developer.garmin.com/fit/overview/) files
 to make them appear to come from a Garmin device (Edge 830, currently) and upload them to Garmin Connect
 using the [`garth`](https://github.com/matin/garth/) library. The FIT editing
 is done using Stages Cycling's [`fit_tool`](https://bitbucket.org/stagescycling/python_fit_tool/src/main/) library.
 
-My primary use case for this is that [indieVelo](https://indievelo.com/) does not support (AFAIK, Garmin does not allow)
+My primary use case for this is that [indieVelo](https://indievelo.com/) / [Zwift](https://www.zwift.com/) does not support (AFAIK, Garmin does not allow)
 automatic uploading to [Garmin Connect](http://connect.garmin.com/). The files can be manually uploaded after the fact,
 but since they are not "from Garmin", they will not be used to calculate Garmin's "Training Effect",
 which is used for suggested workouts and other stuff. By changing the FIT file to appear to come

--- a/garmin.py
+++ b/garmin.py
@@ -100,7 +100,10 @@ def edit_fit(fit_path: Path, output: Optional[Path] = None) -> Path:
                     message.product = GarminProduct.EDGE_830.value                                # type: ignore
                     message.manufacturer = Manufacturer.GARMIN.value
                     print_message(f"    New Record: {i}", message)
-
+        
+        # skip "event" fields. These are used by Zwift
+        if message.global_id == 21: continue
+            
         builder.add(message)
 
     modified_file = builder.build()

--- a/garmin.py
+++ b/garmin.py
@@ -85,7 +85,7 @@ def edit_fit(fit_path: Path, output: Optional[Path] = None) -> Path:
                 dt = datetime.fromtimestamp(message.time_created/1000.0)   # type: ignore
                 _logger.info(f"Activity timestamp is \"{dt.isoformat()}\"")
                 print_message(f"Record: {i}", message)
-                if message.manufacturer == Manufacturer.DEVELOPMENT.value:
+                if message.manufacturer == Manufacturer.DEVELOPMENT.value or message.manufacturer == Manufacturer.ZWIFT.value:
                     _logger.debug('    Modifying values')
                     message.product = GarminProduct.EDGE_830.value
                     message.manufacturer = Manufacturer.GARMIN.value
@@ -95,7 +95,7 @@ def edit_fit(fit_path: Path, output: Optional[Path] = None) -> Path:
         if message.global_id == DeviceInfoMessage.ID:
             if isinstance(message, DeviceInfoMessage):
                 print_message(f"Record: {i}", message)
-                if message.manufacturer == Manufacturer.DEVELOPMENT.value or message.manufacturer == 0 or message.manufacturer == Manufacturer.WAHOO_FITNESS.value:
+                if message.manufacturer == Manufacturer.DEVELOPMENT.value or message.manufacturer == 0 or message.manufacturer == Manufacturer.WAHOO_FITNESS.value or message.manufacturer == Manufacturer.ZWIFT.value:
                     _logger.debug('    Modifying values')
                     message.garmin_product = GarminProduct.EDGE_830.value
                     message.product = GarminProduct.EDGE_830.value                                # type: ignore

--- a/garmin.py
+++ b/garmin.py
@@ -40,8 +40,8 @@ from fit_tool.fit_file_builder import FitFileBuilder
 load_dotenv()
 c = Console()
 
-EDGE830 = GarminProduct.EDGE_830
-GARMIN = Manufacturer.GARMIN
+#EDGE830 = GarminProduct.EDGE_830
+#GARMIN = Manufacturer.GARMIN
 FILES_UPLOADED = Path('.uploaded_files.json')
 
 class FitFileLogFilter(logging.Filter):

--- a/garmin.py
+++ b/garmin.py
@@ -32,6 +32,7 @@ logging.getLogger('oauth1_auth').setLevel(logging.WARNING)
 from fit_tool.fit_file import FitFile
 from fit_tool.profile.messages.device_info_message import DeviceInfoMessage
 from fit_tool.profile.messages.file_id_message import FileIdMessage
+from fit_tool.profile.messages.event_message import EventMessage
 from fit_tool.profile.profile_type import Manufacturer, GarminProduct
 from fit_tool.fit_file_builder import FitFileBuilder
 
@@ -102,7 +103,7 @@ def edit_fit(fit_path: Path, output: Optional[Path] = None) -> Path:
                     print_message(f"    New Record: {i}", message)
         
         # skip "event" fields. These are used by Zwift
-        if message.global_id == 21: continue
+        if message.global_id == EventMessage.ID: continue
             
         builder.add(message)
 


### PR DESCRIPTION
This seems to fix the problem with Zwift files for me. This will close https://github.com/jat255/fit_file_uploader/issues/11

The problem seems to simply be that the ID 21 (Event) isn't supported somewhere in the tool chain. So we just skip it completely. 

The data stored in the event message looks pretty pointless so I think it's safe to remove. Maybe there is a better way to do this?